### PR TITLE
Build workaround

### DIFF
--- a/clean.sh
+++ b/clean.sh
@@ -8,3 +8,15 @@ make clean
 make mrproper
 cd AnyKernel3
 make clean
+
+# Check if a saved toolchain tar exist and refresh from it if so
+cd ..
+if [ -f ../toolchain.tbz ]; then
+	rm -rf stock stock_32 clang
+	tar xjvf ../toolchain.tbz
+else
+	echo Please launch \"gettools.sh\" script to get a toolchain and create a backup archive to restore from!
+	echo -n "Want to run it right now? (Y/n): "
+	read a
+	[ "$a" != "n" ] && sh gettools.sh
+fi


### PR DESCRIPTION
Part of workaround around a toolchain that (by some reason) can be used only before the clean script called.