### PR TITLE
Build workaround (gettools.sh part)

### DIFF
--- a/gettools.sh
+++ b/gettools.sh
@@ -25,3 +25,7 @@ if [ ! -d clang ]; then
     tar xvzf clang-4691093.tar.gz -C clang/clang-4691093
     rm clang-4691093.tar.gz
 fi
+
+# Make a backup for the toolchain to refresh after cleaning by clean.sh script
+#  (avoiding build bug)
+tar cjvf ../toolchain.tbz stock stock_32 clang


### PR DESCRIPTION
Part of workaround around a toolchain that (by some reason) can be used only before the clean script called.